### PR TITLE
fix unicast response port and timeout

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -84,6 +84,7 @@ interface_send_packet4(struct interface *iface, struct sockaddr_in *to, struct i
 			fprintf(stderr, "Ignoring IPv4 address for multicast interface\n");
 	} else {
 		a.sin_addr.s_addr = to->sin_addr.s_addr;
+		a.sin_port = to->sin_port;
 	}
 
 	return sendmsg(fd, &m, 0);

--- a/service.c
+++ b/service.c
@@ -157,7 +157,7 @@ service_reply_single(struct interface *iface, struct sockaddr *to, struct servic
 }
 
 void
-service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl)
+service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force)
 {
 	struct service *s;
 
@@ -166,7 +166,7 @@ service_reply(struct interface *iface, struct sockaddr *to, const char *instance
 			continue;
 		if (service_domain && strcmp(s->service, service_domain))
 			continue;
-		service_reply_single(iface, to, s, ttl, 0);
+		service_reply_single(iface, to, s, ttl, force);
 	}
 }
 

--- a/service.h
+++ b/service.h
@@ -16,7 +16,7 @@
 
 extern void service_init(int announce);
 extern void service_cleanup(void);
-extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl);
+extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force);
 extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl);
 
 #endif


### PR DESCRIPTION
Responses to One-Shot Multicast DNS Queries (as in RFC 6762 5.1) with CLASS_UNICAST set should be sent back to the port of the client and not to 5353. In addition timeouts should be ignored.

The port issue seems to be introduced with commit  4035fe42df588122ec99ac3e16db448b6c3f577d. Since then Unicast replies are sent to port 5353 instead of the source port.

The attached patch is a proposal for a fix and was tested with my mDNS client program on OpenWRT, Android and Debian.