### PR TITLE
dns: fix response to TYPE_PTR query

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -380,8 +380,6 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 
 	case TYPE_PTR:
 		if (!strcmp(name, C_DNS_SD)) {
-			dns_reply_a(iface, to, announce_ttl, NULL);
-			dns_reply_a_additional(iface, to, announce_ttl);
 			service_announce_services(iface, to, announce_ttl);
 		} else {
 			if (name[0] == '_') {


### PR DESCRIPTION
In case of PTR query, sending response of TYPE_A is not needed. As per the rfc 6763, the responder in this case should send list of its services.