### PR TITLE
mdnsd: add handling for legacy queries

### DIFF
--- a/announce.c
+++ b/announce.c
@@ -65,9 +65,9 @@ announce_timer(struct uloop_timeout *timeout)
 			/* Fall through */
 
 		case STATE_ANNOUNCE:
-			dns_reply_a(iface, NULL, announce_ttl, NULL);
+			dns_reply_a(iface, NULL, announce_ttl, NULL, NULL, 0);
 			dns_reply_a_additional(iface, NULL, announce_ttl);
-			service_announce_services(iface, NULL, announce_ttl);
+			service_announce_services(iface, NULL, announce_ttl, NULL, 0);
 			uloop_timeout_set(timeout, announce_ttl * 800);
 			break;
 	}

--- a/dns.h
+++ b/dns.h
@@ -77,8 +77,8 @@ void dns_send_question(struct interface *iface, struct sockaddr *to,
 		       const char *question, int type, int multicast);
 void dns_init_answer(void);
 void dns_add_answer(int type, const uint8_t *rdata, uint16_t rdlength, int ttl);
-void dns_send_answer(struct interface *iface, struct sockaddr *to, const char *answer);
-void dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname);
+void dns_send_answer(struct interface *iface, struct sockaddr *to, const char *answer, uint8_t *orig_buffer, int orig_len);
+void dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, uint8_t *orig_buffer, int orig_len);
 void dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl);
 const char* dns_type_string(uint16_t type);
 void dns_handle_packet(struct interface *iface, struct sockaddr *s, uint16_t port, uint8_t *buf, int len);

--- a/interface.c
+++ b/interface.c
@@ -83,6 +83,7 @@ interface_send_packet4(struct interface *iface, struct sockaddr_in *to, struct i
 		if (to)
 			fprintf(stderr, "Ignoring IPv4 address for multicast interface\n");
 	} else {
+		a.sin_port = to->sin_port;
 		a.sin_addr.s_addr = to->sin_addr.s_addr;
 	}
 
@@ -652,9 +653,9 @@ void interface_shutdown(void)
 
 	vlist_for_each_element(&interfaces, iface, node)
 		if (interface_multicast(iface)) {
-			dns_reply_a(iface, NULL, 0, NULL);
+			dns_reply_a(iface, NULL, 0, NULL, NULL, 0);
 			dns_reply_a_additional(iface, NULL, 0);
-			service_announce_services(iface, NULL, 0);
+			service_announce_services(iface, NULL, 0, NULL, 0);
 		}
 
 	for (size_t i = 0; i < ARRAY_SIZE(ufd); i++) {

--- a/service.h
+++ b/service.h
@@ -23,7 +23,8 @@ extern struct vlist_tree hostnames;
 
 extern void service_init(int announce);
 extern void service_cleanup(void);
-extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl);
-extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl);
+extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl,
+		uint8_t *orig_buffer, int orig_len);
+extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl, uint8_t *orig_buffer, int orig_len);
 
 #endif


### PR DESCRIPTION
Following are taken care of:
- in the reply to a legacy query, send unicast udp to same port from which the packet is received.
- copy the query from question message in reply.
- use the same transaction id as in question.

Fixes bug FS #3 