### PR TITLE
[23.05] interface: fix interface memory corruption

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -464,6 +464,7 @@ iface_update_cb(struct vlist_tree *tree, struct vlist_node *node_new,
 			cache_cleanup(if_old);
 		free(if_old->addrs.v4);
 		if_old->addrs = if_new->addrs;
+		if_old->ifindex = if_new->ifindex;
 		free(if_new);
 		return;
 	}
@@ -669,4 +670,4 @@ struct interface *interface_get(const char *name, enum umdns_socket_type type)
 	return iface;
 }
 
-VLIST_TREE(interfaces, avl_strcmp, iface_update_cb, false, false);
+VLIST_TREE(interfaces, avl_strcmp, iface_update_cb, true, false);


### PR DESCRIPTION
- set vlist keep_old=true, because the iface_update_cb expects it
- update ifindex on reload

Fixes: openwrt/openwrt/issues/14120
Signed-off-by: Felix Fietkau <nbd@nbd.name>
(cherry picked from commit 9040335e102b83a2dd7df64aa88d0dd762d78a86)