### PR TITLE
dns: support legacy queries

### DIFF
--- a/announce.c
+++ b/announce.c
@@ -65,9 +65,9 @@ announce_timer(struct uloop_timeout *timeout)
 			/* Fall through */
 
 		case STATE_ANNOUNCE:
-			dns_reply_a(iface, NULL, announce_ttl, NULL);
-			dns_reply_a_additional(iface, NULL, announce_ttl);
-			service_announce_services(iface, NULL, announce_ttl);
+			dns_reply_a(iface, NULL, announce_ttl, NULL, false);
+			dns_reply_a_additional(iface, NULL, announce_ttl, false);
+			service_announce_services(iface, NULL, announce_ttl, false);
 			uloop_timeout_set(timeout, announce_ttl * 800);
 			break;
 	}

--- a/dns.h
+++ b/dns.h
@@ -82,8 +82,8 @@ void dns_query(const char *name, uint16_t type);
 
 void dns_send_question(struct interface *iface, struct sockaddr *to,
 		       const char *question, int type, int multicast);
-void dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname);
-void dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl);
+void dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, bool append);
+void dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl, bool append);
 const char* dns_type_string(uint16_t type);
 void dns_handle_packet(struct interface *iface, struct sockaddr *s, uint16_t port, uint8_t *buf, int len);
 

--- a/interface.c
+++ b/interface.c
@@ -666,9 +666,9 @@ void interface_shutdown(void)
 
 	vlist_for_each_element(&interfaces, iface, node)
 		if (interface_multicast(iface)) {
-			dns_reply_a(iface, NULL, 0, NULL);
-			dns_reply_a_additional(iface, NULL, 0);
-			service_announce_services(iface, NULL, 0);
+			dns_reply_a(iface, NULL, 0, NULL, false);
+			dns_reply_a_additional(iface, NULL, 0, false);
+			service_announce_services(iface, NULL, 0, false);
 		}
 
 	for (size_t i = 0; i < ARRAY_SIZE(ufd); i++) {

--- a/service.h
+++ b/service.h
@@ -42,8 +42,8 @@ extern struct vlist_tree announced_services;
 
 extern void service_init(int announce);
 extern void service_cleanup(void);
-extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force);
-extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl);
+extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force, bool append);
+extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl, bool append);
 extern void service_update(struct vlist_tree *tree, struct vlist_node *node_new, struct vlist_node *node_old);
 
 #endif


### PR DESCRIPTION
dns: add support for Legacy Unicast Responses

For example, in case the query is of the type "One-Shot Multicast
DNS Queries", the questions also need to be sent along with the
answer, like a conventional DNS response (RFC 6762 Section 6.7).
Therefore, we save the question section while parsing DNS question.

dns: save question section when parsing DNS question

As per RFC 6762 Section 6.7 (Legacy Unicast Responses)

"If the source UDP port in a received Multicast DNS query is not port
5353, this indicates that the querier originating the query is a
simple resolver such as described in Section 5.1, "One-Shot Multicast
DNS Queries", which does not fully implement all of Multicast DNS.
In this case, the Multicast DNS responder MUST send a UDP response
directly back to the querier, via unicast, to the query packet's
source IP address and port.  This unicast response MUST be a
conventional unicast response as would be generated by a conventional
Unicast DNS server; for example, it MUST repeat the query ID and the
question given in the query message."

Therefore, umdns should not ignore DNS questions coming from non-
multicast sources, and also provide question section which is not
usually provided in mDNS responses.

Signed-off-by: Mohd Husaam Mehdi <husaam.mehdi@iopsys.eu>