### PR TITLE
dns: check there is room in answer packet

### DIFF
--- a/dns.h
+++ b/dns.h
@@ -75,7 +75,7 @@ extern int cfg_no_subnet;
 
 void dns_packet_init(void);
 bool dns_packet_question(const char *name, int type);
-void dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl);
+bool dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl);
 void dns_packet_send(struct interface *iface, struct sockaddr *to, bool query, int multicast);
 
 void dns_query(const char *name, uint16_t type);


### PR DESCRIPTION
I came across some crashes on some of my systems that looks like this:
```
#0  0x0000000000406fa0 in dns_packet_answer (name=name@entry=0x4206a4 <mdns_hostname_local> \"854-v6-XXXX.local\", type=type@entry=28, rdata=0x7fb4013858 \"\\376\\200\", rdlength=rdlength@entry=16, ttl=ttl@entry=4500) at dns.c:161
161     a->type = cpu_to_be16(type);
The target architecture is set to \"aarch64\".",
#0  0x0000000000406fa0 in dns_packet_answer (name=name@entry=0x4206a4 <mdns_hostname_local> \"854-v6-XXXX.local\", type=type@entry=28, rdata=0x7fb4013858 \"\\376\\200\", rdlength=rdlength@entry=16, ttl=ttl@entry=4500) at dns.c:161
#1  0x00000000004073e0 in dns_reply_a (iface=iface@entry=0x7fb3f25e40, to=to@entry=0x0, ttl=4500, hostname=0x4206a4 <mdns_hostname_local> \"854-v6-XXXX.local\", hostname@entry=0x0) at dns.c:290
#2  0x0000000000402a18 in announce_timer (timeout=0x7fb3f25ea8) at announce.c:68
#3  0x0000007fb3f6ed24 in uloop_process_timeouts () at uloop.c:633
#4  uloop_run_timeout (timeout=timeout@entry=-1) at uloop.c:667
#5  0x0000000000402730 in uloop_run () at /usr/include/libubox/uloop.h:149
#6  main (argc=1, argv=0x7fedda97f8) at main.c:142
```

I am no able to recreate the issue on demand. Looking through the code, I would guess the crash is caused by `dns_packet_answer` not checking if there is enough room in the packet (causing us to de-reference `NULL`).

This patch changes the code to do this patch and skip adding an answer if there is not enough room.