### PR TITLE
Fix buffer overflow in parsing ipv6 ptr queries

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -452,14 +452,21 @@ match_ipv6_addresses(char *reverse_ip, struct in6_addr *intf_ip)
 			continue;
 
 		if (j == 4) {
+			if (idx == sizeof temp_ip - 1)
+				break;
 			temp_ip[idx] = ':';
 			idx++;
 			j = 0;
 		}
+		
+		if (idx == sizeof temp_ip - 1)
+			break;
 		temp_ip[idx] = reverse_ip[i];
 		idx++;
 		j++;
 	}
+
+	temp_ip[idx] = '\0';
 
 	if (inet_pton(AF_INET6, temp_ip, &buf) <= 0)
 		return 0;


### PR DESCRIPTION
Fixes a buffer overflow (or should) in parsing ipv6 ptr queries. 

In normal circumstances (buildbot builds) you are saved by the compiler with the inlining padding the stack and nothing useful to overwrite for now.

Building without optimisation and debugging:

```
root@OpenWrt:~# gdb /usr/sbin/umdns
GNU gdb (GDB) 16.3
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "arm-openwrt-linux".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/sbin/umdns...
(gdb) r -i br-lan
Starting program: /usr/sbin/umdns -i br-lan
No IP address specified for unicast interface

Program received signal SIGILL, Illegal instruction.
0xb6fa86e8 in ?? ()
(gdb) bt
#0  0xb6fa86e8 in ?? ()
#1  0x000166fc in match_ipv6_addresses (
    reverse_ip=0x22108 <name_buffer> "AAAAAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA.ABBBAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA.AAAAAAAA", intf_ip=0xb6f1da98) at /home/aaaa/build/openwrt/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/umdns-2025.10.04~2f75344f/dns.c:468
#2  0x4242423a in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

[https://digit-labs.org/files/exploits/owrt-umdns.c](https://digit-labs.org/files/exploits/owrt-umdns.c)