### PR TITLE
fix: explicitly cast calloc_a variadic length arguments to size_t

### DIFF
--- a/announce.c
+++ b/announce.c
@@ -65,9 +65,9 @@ announce_timer(struct uloop_timeout *timeout)
 			/* Fall through */
 
 		case STATE_ANNOUNCE:
-			dns_reply_a(iface, NULL, announce_ttl, NULL);
-			dns_reply_a_additional(iface, NULL, announce_ttl);
-			service_announce_services(iface, NULL, announce_ttl);
+			dns_reply_a(iface, NULL, announce_ttl, NULL, false);
+			dns_reply_a_additional(iface, NULL, announce_ttl, false);
+			service_announce_services(iface, NULL, announce_ttl, false);
 			uloop_timeout_set(timeout, announce_ttl * 800);
 			break;
 	}

--- a/cache.c
+++ b/cache.c
@@ -204,7 +204,7 @@ cache_service(struct interface *iface, char *entry, size_t hlen, int ttl)
 
 	s = calloc_a(sizeof(*s),
 		&entry_buf, strlen(entry) + 1,
-		&host_buf, hlen ? hlen + sizeof(".local") + 1 : 0);
+		&host_buf, hlen ? hlen + sizeof(".local") + 1 : (size_t)0);
 	if (!s)
 		return NULL;
 
@@ -405,8 +405,8 @@ void cache_answer(struct interface *iface, struct sockaddr *from, uint8_t *base,
 
 	r = calloc_a(sizeof(*r),
 		&name_buf, strlen(name) + 1,
-		&txt_ptr, tlen,
-		&rdata_ptr, dlen);
+		&txt_ptr, (size_t)tlen,
+		&rdata_ptr, (size_t)dlen);
 	if (!r)
 		return;
 

--- a/cache.c
+++ b/cache.c
@@ -180,7 +180,7 @@ cache_service(struct interface *iface, char *entry, size_t hlen, int ttl)
 
 	s = calloc_a(sizeof(*s),
 		&entry_buf, strlen(entry) + 1,
-		&host_buf, hlen ? hlen + sizeof(".local") + 1 : 0);
+		&host_buf, hlen ? hlen + sizeof(".local") + 1 : (size_t)0);
 
 	s->avl.key = s->entry = strcpy(entry_buf, entry);
 	s->time = monotonic_time();
@@ -366,8 +366,8 @@ void cache_answer(struct interface *iface, struct sockaddr *from, uint8_t *base,
 
 	r = calloc_a(sizeof(*r),
 		&name_buf, strlen(name) + 1,
-		&txt_ptr, tlen,
-		&rdata_ptr, dlen);
+		&txt_ptr, (size_t)tlen,
+		&rdata_ptr, (size_t)dlen);
 
 	r->avl.key = r->record = strcpy(name_buf, name);
 	r->type = a->type;

--- a/dns.c
+++ b/dns.c
@@ -273,7 +273,7 @@ void dns_query(const char *name, uint16_t type)
 }
 
 void
-dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname)
+dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, bool append)
 {
 	struct ifaddrs *ifap, *ifa;
 	struct sockaddr_in *sa;
@@ -284,7 +284,9 @@ dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *h
 
 	getifaddrs(&ifap);
 
-	dns_packet_init();
+	if (!append)
+		dns_packet_init();
+
 	for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
 		if (strcmp(ifa->ifa_name, iface->name))
 			continue;
@@ -299,16 +301,17 @@ dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *h
 	}
 	freeifaddrs(ifap);
 
-	dns_packet_send(iface, to, 0, 0);
+	if(!append)
+		dns_packet_send(iface, to, 0, 0);
 }
 
 void
-dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl)
+dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl, bool append)
 {
 	struct hostname *h;
 
 	vlist_for_each_element(&hostnames, h, node)
-		dns_reply_a(iface, to, ttl, h->hostname);
+		dns_reply_a(iface, to, ttl, h->hostname, append);
 }
 
 static int
@@ -500,7 +503,8 @@ match_ip_addresses(char *reverse_ip, char *intf_ip)
 }
 
 static void
-dns_reply_reverse_ip6_mapping(struct interface *iface, struct sockaddr *to, int ttl, char *name, char *reverse_ip)
+dns_reply_reverse_ip6_mapping(struct interface *iface, struct sockaddr *to, int ttl, char *name, char *reverse_ip,
+				bool append)
 {
 	struct ifaddrs *ifap, *ifa;
 	struct sockaddr_in6 *sa6;
@@ -510,7 +514,10 @@ dns_reply_reverse_ip6_mapping(struct interface *iface, struct sockaddr *to, int 
 	int len;
 
 	getifaddrs(&ifap);
-	dns_packet_init();
+
+	if (!append)
+		dns_packet_init();
+
 	for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
 		if (strcmp(ifa->ifa_name, iface->name))
 			continue;
@@ -529,13 +536,16 @@ dns_reply_reverse_ip6_mapping(struct interface *iface, struct sockaddr *to, int 
 			}
 		}
 	}
-	dns_packet_send(iface, to, 0, 0);
+
+	if (!append)
+		dns_packet_send(iface, to, 0, 0);
 
 	freeifaddrs(ifap);
 }
 
 static void
-dns_reply_reverse_ip4_mapping(struct interface *iface, struct sockaddr *to, int ttl, char *name, char *reverse_ip)
+dns_reply_reverse_ip4_mapping(struct interface *iface, struct sockaddr *to, int ttl, char *name, char *reverse_ip,
+				bool append)
 {
 	struct ifaddrs *ifap, *ifa;
 	struct sockaddr_in *sa;
@@ -545,7 +555,10 @@ dns_reply_reverse_ip4_mapping(struct interface *iface, struct sockaddr *to, int 
 	int len;
 
 	getifaddrs(&ifap);
-	dns_packet_init();
+
+	if (!append)
+		dns_packet_init();
+
 	for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
 		if (strcmp(ifa->ifa_name, iface->name))
 			continue;
@@ -564,7 +577,8 @@ dns_reply_reverse_ip4_mapping(struct interface *iface, struct sockaddr *to, int 
 			}
 		}
 	}
-	dns_packet_send(iface, to, 0, 0);
+	if (!append)
+		dns_packet_send(iface, to, 0, 0);
 
 	freeifaddrs(ifap);
 }
@@ -588,7 +602,7 @@ is_reverse_dns_query(const char *name, const char *suffix)
 }
 
 static void
-parse_question(struct interface *iface, struct sockaddr *from, char *name, struct dns_question *q)
+parse_question(struct interface *iface, struct sockaddr *from, char *name, struct dns_question *q, bool append)
 {
 	int is_unicast = (q->class & CLASS_UNICAST) != 0;
 	struct sockaddr *to = NULL;
@@ -597,9 +611,12 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 
 	/* TODO: Multicast if more than one quarter of TTL has passed */
 	if (is_unicast) {
-		to = from;
-		if (interface_multicast(iface))
-			iface = interface_get(iface->name, iface->type | SOCKTYPE_BIT_UNICAST);
+		/* if append is true we have already done this */
+		if (!append) {
+			to = from;
+			if (interface_multicast(iface))
+				iface = interface_get(iface->name, iface->type | SOCKTYPE_BIT_UNICAST);
+		}
 	}
 
 	DBG(1, "Q -> %s %s\n", dns_type_string(q->type), name);
@@ -607,9 +624,9 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 	switch (q->type) {
 	case TYPE_ANY:
 		if (!strcasecmp(name, mdns_hostname_local)) {
-			dns_reply_a(iface, to, announce_ttl, NULL);
-			dns_reply_a_additional(iface, to, announce_ttl);
-			service_reply(iface, to, NULL, NULL, announce_ttl, is_unicast);
+			dns_reply_a(iface, to, announce_ttl, NULL, append);
+			dns_reply_a_additional(iface, to, announce_ttl, append);
+			service_reply(iface, to, NULL, NULL, announce_ttl, is_unicast, append);
 		}
 		break;
 
@@ -623,7 +640,7 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 			char name_buf[256];
 			strcpy(name_buf, name);
 			*host = '\0';
-			dns_reply_reverse_ip4_mapping(iface, to, announce_ttl, name_buf, name);
+			dns_reply_reverse_ip4_mapping(iface, to, announce_ttl, name_buf, name, append);
 			break;
 		}
 
@@ -635,22 +652,22 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 			char name_buf6[256];
 			strcpy(name_buf6, name);
 			*host6 = '\0';
-			dns_reply_reverse_ip6_mapping(iface, to, announce_ttl, name_buf6, name);
+			dns_reply_reverse_ip6_mapping(iface, to, announce_ttl, name_buf6, name, append);
 			break;
 		}
 
 		if (!strcasecmp(name, C_DNS_SD)) {
-			service_announce_services(iface, to, announce_ttl);
+			service_announce_services(iface, to, announce_ttl, append);
 		} else {
 			if (name[0] == '_') {
-				service_reply(iface, to, NULL, name, announce_ttl, is_unicast);
+				service_reply(iface, to, NULL, name, announce_ttl, is_unicast, append);
 			} else {
 				/* First dot separates instance name from the rest */
 				char *dot = strchr(name, '.');
 
 				if (dot) {
 					*dot = '\0';
-					service_reply(iface, to, name, dot + 1, announce_ttl, is_unicast);
+					service_reply(iface, to, name, dot + 1, announce_ttl, is_unicast, append);
 					*dot = '.';
 				}
 			}
@@ -663,16 +680,43 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 		if (host)
 			*host = '\0';
 		if (!strcasecmp(umdns_host_label, name)) {
-			dns_reply_a(iface, to, announce_ttl, NULL);
+			dns_reply_a(iface, to, announce_ttl, NULL, append);
 		} else {
 			if (host)
 				*host = '.';
 			vlist_for_each_element(&hostnames, h, node)
 				if (!strcasecmp(h->hostname, name))
-					dns_reply_a(iface, to, announce_ttl, h->hostname);
+					dns_reply_a(iface, to, announce_ttl, h->hostname, append);
 		}
 		break;
 	};
+}
+
+static void
+dns_append_questions(uint8_t *orig_buffer, int orig_len)
+{
+	/* Construct original question section */
+	const struct dns_header *orig_h;
+	uint8_t *ptr = orig_buffer;
+	int len = orig_len;
+
+	orig_h = dns_consume_header(&ptr, &len);
+	if (orig_h) {
+		pkt.h.id = cpu_to_be16(orig_h->id);
+
+		uint16_t q_count = be16_to_cpu(orig_h->questions);
+		while (q_count-- > 0 && len > 0) {
+			char *qname = dns_consume_name(orig_buffer, orig_len, &ptr, &len);
+			if (!qname || len < (int)sizeof(struct dns_question))
+				break;
+
+			struct dns_question *q = dns_consume_question(&ptr, &len);
+			if (!q)
+				break;
+
+			dns_packet_question(qname, q->type);
+		}
+	}
 }
 
 void
@@ -681,6 +725,13 @@ dns_handle_packet(struct interface *iface, struct sockaddr *from, uint16_t port,
 	struct dns_header *h;
 	uint8_t *b = buffer;
 	int rlen = len;
+	uint8_t orig_buffer[len];
+	struct sockaddr *to = NULL;
+	bool append = false;
+
+	/* make a copy of the original buffer since it might be needed to construct the answer
+	 * in case the query is received from a one-shot multicast dns querier */
+	memcpy(orig_buffer, buffer, len);
 
 	h = dns_consume_header(&b, &rlen);
 	if (!h) {
@@ -688,9 +739,22 @@ dns_handle_packet(struct interface *iface, struct sockaddr *from, uint16_t port,
 		return;
 	}
 
-	if (h->questions && !interface_multicast(iface) && port != MCAST_PORT)
-		/* silently drop unicast questions that dont originate from port 5353 */
-		return;
+	/* legacy querier */
+	if (port != MCAST_PORT) {
+		/* aggregate answers and send, instead of sending separately */
+		append = true;
+
+		/* packet construction starts here */
+		dns_packet_init();
+
+		/* add original questions, as outlined by RFC 6762 Section 6.7 */
+		dns_append_questions(orig_buffer, len);
+
+		/* to return a unicast response */
+		to = from;
+		if (interface_multicast(iface))
+			iface = interface_get(iface->name, iface->type | SOCKTYPE_BIT_UNICAST);
+	}
 
 	while (h->questions-- > 0) {
 		char *name = dns_consume_name(buffer, len, &b, &rlen);
@@ -708,8 +772,12 @@ dns_handle_packet(struct interface *iface, struct sockaddr *from, uint16_t port,
 		}
 
 		if (!(h->flags & FLAG_RESPONSE))
-			parse_question(iface, from, name, q);
+			parse_question(iface, from, name, q, append);
 	}
+
+	/* if append is true, then answers have only been appended to the packet, not sent, so we do that here */
+	if (append && pkt.h.answers > 0)
+		dns_packet_send(iface, to, 0, 0);
 
 	if (!(h->flags & FLAG_RESPONSE))
 		return;

--- a/dns.c
+++ b/dns.c
@@ -769,10 +769,17 @@ dns_handle_packet(struct interface *iface, struct sockaddr *from, uint16_t port,
 	struct dns_header *h;
 	uint8_t *b = buffer;
 	int rlen = len;
-	uint8_t orig_buffer[len];
+	uint8_t orig_buffer_fixed[1500];
+	uint8_t *orig_buffer = orig_buffer_fixed;
 	struct sockaddr *to = NULL;
 	bool append = false;
 
+	if (len > 1500) {
+		orig_buffer = malloc(len);
+		if (!orig_buffer)
+			return;
+		DBG(0, "dns_handle_packet oversized mDNS packet (len: %d)\n", len);
+	}
 	/* make a copy of the original buffer since it might be needed to construct the answer
 	 * in case the query is received from a one-shot multicast dns querier */
 	memcpy(orig_buffer, buffer, len);
@@ -780,7 +787,7 @@ dns_handle_packet(struct interface *iface, struct sockaddr *from, uint16_t port,
 	h = dns_consume_header(&b, &rlen);
 	if (!h) {
 		fprintf(stderr, "dropping: bad header\n");
-		return;
+		goto cleanup;
 	}
 
 	/* legacy querier */
@@ -806,13 +813,13 @@ dns_handle_packet(struct interface *iface, struct sockaddr *from, uint16_t port,
 
 		if (!name || rlen < 0) {
 			fprintf(stderr, "dropping: bad name\n");
-			return;
+			goto cleanup;
 		}
 
 		q = dns_consume_question(&b, &rlen);
 		if (!q) {
 			fprintf(stderr, "dropping: bad question\n");
-			return;
+			goto cleanup;
 		}
 
 		if (!(h->flags & FLAG_RESPONSE))
@@ -824,18 +831,21 @@ dns_handle_packet(struct interface *iface, struct sockaddr *from, uint16_t port,
 		dns_packet_send(iface, to, 0, 0);
 
 	if (!(h->flags & FLAG_RESPONSE))
-		return;
+		goto cleanup;
 
 	while (h->answers-- > 0)
 		if (parse_answer(iface, from, buffer, len, &b, &rlen, 1))
-			return;
+			goto cleanup;
 
 	while (h->authority-- > 0)
 		if (parse_answer(iface, from, buffer, len, &b, &rlen, 1))
-			return;
+			goto cleanup;
 
 	while (h->additional-- > 0)
 		if (parse_answer(iface, from, buffer, len, &b, &rlen, 1))
-			return;
+			goto cleanup;
 
+cleanup:
+	if (orig_buffer != orig_buffer_fixed)
+		free(orig_buffer);
 }

--- a/dns.c
+++ b/dns.c
@@ -150,7 +150,7 @@ bool dns_packet_question(const char *name, int type)
 	return true;
 }
 
-bool dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl)
+static bool dns_packet_record(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl)
 {
 	struct dns_answer *a;
 
@@ -158,7 +158,7 @@ bool dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_
 
 	a = dns_packet_record_add(sizeof(*a) + rdlength, name);
 	if (!a) {
-		DBG(0, "Not enough room for answer %d\n", be16_to_cpu(pkt.h.answers)+1);
+		DBG(0, "Not enough room for record\n");
 		return false;
 	}
 
@@ -170,8 +170,20 @@ bool dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_
 	memcpy(a + 1, rdata, rdlength);
 	DBG(1, "A <- %s %s\n", dns_type_string(be16_to_cpu(a->type)), name);
 
-	pkt.h.answers += cpu_to_be16(1);
 	return true;
+}
+
+bool dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl)
+{
+	if (dns_packet_record(name, type, rdata, rdlength, ttl))
+		pkt.h.answers += cpu_to_be16(1);
+	return true;
+}
+
+void dns_packet_additional(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl)
+{
+	if (dns_packet_record(name, type, rdata, rdlength, ttl))
+		pkt.h.additional += cpu_to_be16(1);
 }
 
 static void dns_question_set_multicast(struct dns_question *q, bool val)
@@ -189,6 +201,9 @@ void dns_packet_send(struct interface *iface, struct sockaddr *to, bool query, i
 		.iov_len = sizeof(pkt.h) + pkt_len,
 	};
 	size_t i;
+
+	if ((query && pkt.h.questions == 0) || (!query && pkt.h.answers == 0))
+		return;
 
 	if (query) {
 		if (multicast < 0)
@@ -273,7 +288,7 @@ void dns_query(const char *name, uint16_t type)
 }
 
 void
-dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, bool append)
+dns_reply_a_qtype(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, uint16_t qtype, bool append)
 {
 	struct ifaddrs *ifap, *ifa;
 	struct sockaddr_in *sa;
@@ -290,19 +305,45 @@ dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *h
 	for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
 		if (strcmp(ifa->ifa_name, iface->name))
 			continue;
-		if (ifa->ifa_addr->sa_family == AF_INET) {
+		if (ifa->ifa_addr->sa_family == AF_INET && (qtype == TYPE_ANY || qtype == TYPE_A)) {
 			sa = (struct sockaddr_in *) ifa->ifa_addr;
 			dns_packet_answer(hostname, TYPE_A, (uint8_t *) &sa->sin_addr, 4, ttl);
 		}
-		if (ifa->ifa_addr->sa_family == AF_INET6) {
+		if (ifa->ifa_addr->sa_family == AF_INET6 && (qtype == TYPE_ANY || qtype == TYPE_AAAA)) {
 			sa6 = (struct sockaddr_in6 *) ifa->ifa_addr;
 			dns_packet_answer(hostname, TYPE_AAAA, (uint8_t *) &sa6->sin6_addr, 16, ttl);
+		}
+	}
+
+	if (qtype == TYPE_A) {
+		for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
+			if (strcmp(ifa->ifa_name, iface->name))
+				continue;
+			if (ifa->ifa_addr->sa_family == AF_INET6) {
+				sa6 = (struct sockaddr_in6 *) ifa->ifa_addr;
+				dns_packet_additional(hostname, TYPE_AAAA, (uint8_t *) &sa6->sin6_addr, 16, ttl);
+			}
+		}
+	} else if (qtype == TYPE_AAAA) {
+		for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
+			if (strcmp(ifa->ifa_name, iface->name))
+				continue;
+			if (ifa->ifa_addr->sa_family == AF_INET) {
+				sa = (struct sockaddr_in *) ifa->ifa_addr;
+				dns_packet_additional(hostname, TYPE_A, (uint8_t *) &sa->sin_addr, 4, ttl);
+			}
 		}
 	}
 	freeifaddrs(ifap);
 
 	if(!append)
 		dns_packet_send(iface, to, 0, 0);
+}
+
+void
+dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, bool append)
+{
+	dns_reply_a_qtype(iface, to, ttl, hostname, TYPE_ANY, append);
 }
 
 void
@@ -626,7 +667,7 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 		if (!strcasecmp(name, mdns_hostname_local)) {
 			dns_reply_a(iface, to, announce_ttl, NULL, append);
 			dns_reply_a_additional(iface, to, announce_ttl, append);
-			service_reply(iface, to, NULL, NULL, announce_ttl, is_unicast, append);
+			service_reply(iface, to, NULL, NULL, announce_ttl, is_unicast, q->type, append);
 		}
 		break;
 
@@ -658,18 +699,21 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 
 		if (!strcasecmp(name, C_DNS_SD)) {
 			service_announce_services(iface, to, announce_ttl, append);
-		} else {
-			if (name[0] == '_') {
-				service_reply(iface, to, NULL, name, announce_ttl, is_unicast, append);
-			} else {
-				/* First dot separates instance name from the rest */
-				char *dot = strchr(name, '.');
+		} else if (name[0] == '_') {
+			service_reply(iface, to, NULL, name, announce_ttl, 1, q->type, append);
+		}
+		break;
 
-				if (dot) {
-					*dot = '\0';
-					service_reply(iface, to, name, dot + 1, announce_ttl, is_unicast, append);
-					*dot = '.';
-				}
+	case TYPE_SRV:
+	case TYPE_TXT:
+		if (name[0] != '_') {
+			/* First dot separates instance name from the rest */
+			char *dot = strchr(name, '.');
+
+			if (dot) {
+				*dot = '\0';
+				service_reply(iface, to, name, dot + 1, announce_ttl, 1, q->type, append);
+				*dot = '.';
 			}
 		}
 		break;
@@ -680,13 +724,13 @@ parse_question(struct interface *iface, struct sockaddr *from, char *name, struc
 		if (host)
 			*host = '\0';
 		if (!strcasecmp(umdns_host_label, name)) {
-			dns_reply_a(iface, to, announce_ttl, NULL, append);
+			dns_reply_a_qtype(iface, to, announce_ttl, NULL, q->type, append);
 		} else {
 			if (host)
 				*host = '.';
 			vlist_for_each_element(&hostnames, h, node)
 				if (!strcasecmp(h->hostname, name))
-					dns_reply_a(iface, to, announce_ttl, h->hostname, append);
+					dns_reply_a_qtype(iface, to, announce_ttl, h->hostname, q->type, append);
 		}
 		break;
 	};

--- a/dns.c
+++ b/dns.c
@@ -235,6 +235,7 @@ dns_query_pending(struct uloop_timeout *t)
 
 		count = 0;
 		dns_packet_broadcast();
+		dns_packet_init();
 	}
 
 	if (count)

--- a/dns.h
+++ b/dns.h
@@ -82,7 +82,7 @@ extern int cfg_no_subnet;
 
 void dns_packet_init(void);
 bool dns_packet_question(const char *name, int type);
-void dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl);
+bool dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl);
 void dns_packet_send(struct interface *iface, struct sockaddr *to, bool query, int multicast);
 
 void dns_query(const char *name, uint16_t type);

--- a/dns.h
+++ b/dns.h
@@ -89,8 +89,8 @@ void dns_query(const char *name, uint16_t type);
 
 void dns_send_question(struct interface *iface, struct sockaddr *to,
 		       const char *question, int type, int multicast);
-void dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname);
-void dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl);
+void dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, bool append);
+void dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl, bool append);
 const char* dns_type_string(uint16_t type);
 void dns_handle_packet(struct interface *iface, struct sockaddr *s, uint16_t port, uint8_t *buf, int len);
 

--- a/dns.h
+++ b/dns.h
@@ -83,6 +83,7 @@ extern int cfg_no_subnet;
 void dns_packet_init(void);
 bool dns_packet_question(const char *name, int type);
 bool dns_packet_answer(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl);
+void dns_packet_additional(const char *name, int type, const uint8_t *rdata, uint16_t rdlength, int ttl);
 void dns_packet_send(struct interface *iface, struct sockaddr *to, bool query, int multicast);
 
 void dns_query(const char *name, uint16_t type);
@@ -90,6 +91,7 @@ void dns_query(const char *name, uint16_t type);
 void dns_send_question(struct interface *iface, struct sockaddr *to,
 		       const char *question, int type, int multicast);
 void dns_reply_a(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, bool append);
+void dns_reply_a_qtype(struct interface *iface, struct sockaddr *to, int ttl, const char *hostname, uint16_t qtype, bool append);
 void dns_reply_a_additional(struct interface *iface, struct sockaddr *to, int ttl, bool append);
 const char* dns_type_string(uint16_t type);
 void dns_handle_packet(struct interface *iface, struct sockaddr *s, uint16_t port, uint8_t *buf, int len);

--- a/interface.c
+++ b/interface.c
@@ -666,9 +666,9 @@ void interface_shutdown(void)
 
 	vlist_for_each_element(&interfaces, iface, node)
 		if (interface_multicast(iface)) {
-			dns_reply_a(iface, NULL, 0, NULL);
-			dns_reply_a_additional(iface, NULL, 0);
-			service_announce_services(iface, NULL, 0);
+			dns_reply_a(iface, NULL, 0, NULL, false);
+			dns_reply_a_additional(iface, NULL, 0, false);
+			service_announce_services(iface, NULL, 0, false);
 		}
 
 	for (size_t i = 0; i < ARRAY_SIZE(ufd); i++) {

--- a/service.c
+++ b/service.c
@@ -259,11 +259,11 @@ service_load_blob(struct blob_attr *b)
 
 	n = strlen(blobmsg_name(b));
 	s = calloc_a(sizeof(*s),
-		&d_id, n + 1,
-		&d_hostname, _tb[SERVICE_HOSTNAME] ? strlen(blobmsg_get_string(_tb[SERVICE_HOSTNAME])) + 1 : 0,
-		&d_instance, _tb[SERVICE_INSTANCE] ? strlen(blobmsg_get_string(_tb[SERVICE_INSTANCE])) + 1 : 0,
+		&d_id, (size_t)(n + 1),
+		&d_hostname, _tb[SERVICE_HOSTNAME] ? strlen(blobmsg_get_string(_tb[SERVICE_HOSTNAME])) + 1 : (size_t)0,
+		&d_instance, _tb[SERVICE_INSTANCE] ? strlen(blobmsg_get_string(_tb[SERVICE_INSTANCE])) + 1 : (size_t)0,
 		&d_service, strlen(blobmsg_get_string(_tb[SERVICE_SERVICE])) + 1,
-		&d_txt, txt_len);
+		&d_txt, (size_t)txt_len);
 	if (!s)
 		return;
 

--- a/service.c
+++ b/service.c
@@ -120,7 +120,8 @@ service_timeout(struct service *s)
 }
 
 static void
-service_reply_single(struct interface *iface, struct sockaddr *to, struct service *s, int ttl, int force)
+service_reply_single(struct interface *iface, struct sockaddr *to, struct service *s, int ttl, int force,
+			bool append)
 {
 	const char *host = service_instance_name(s);
 	char *service = strstr(host, "._");
@@ -133,16 +134,21 @@ service_reply_single(struct interface *iface, struct sockaddr *to, struct servic
 
 	s->t = t;
 
-	dns_packet_init();
+	if (!append)
+		dns_packet_init();
+
 	service_add_ptr(service, service_instance_name(s), ttl);
 	service_add_srv(host, s, ttl);
 	if (s->txt && s->txt_len)
 		dns_packet_answer(host, TYPE_TXT, (uint8_t *) s->txt, s->txt_len, ttl);
-	dns_packet_send(iface, to, 0, 0);
+
+	if (!append)
+		dns_packet_send(iface, to, 0, 0);
 }
 
 void
-service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force)
+service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force,
+		bool append)
 {
 	struct service *s;
 
@@ -151,17 +157,19 @@ service_reply(struct interface *iface, struct sockaddr *to, const char *instance
 			continue;
 		if (service_domain && strcmp(s->service, service_domain))
 			continue;
-		service_reply_single(iface, to, s, ttl, force);
+		service_reply_single(iface, to, s, ttl, force, append);
 	}
 }
 
 void
-service_announce_services(struct interface *iface, struct sockaddr *to, int ttl)
+service_announce_services(struct interface *iface, struct sockaddr *to, int ttl, bool append)
 {
 	struct service *s;
 	int count = 0;
 
-	dns_packet_init();
+	if (!append)
+		dns_packet_init();
+
 	vlist_for_each_element(&announced_services, s, node) {
 		s->t = 0;
 		if (ttl) {
@@ -170,7 +178,8 @@ service_announce_services(struct interface *iface, struct sockaddr *to, int ttl)
 		}
 	}
 	if (count)
-		dns_packet_send(iface, to, 0, 0);
+		if (!append)
+			dns_packet_send(iface, to, 0, 0);
 }
 
 void
@@ -185,7 +194,7 @@ service_update(struct vlist_tree *tree, struct vlist_node *node_new,
 		if (service_init_announce)
 			vlist_for_each_element(&interfaces, iface, node) {
 				s->t = 0;
-				service_reply_single(iface, NULL, s, announce_ttl, 1);
+				service_reply_single(iface, NULL, s, announce_ttl, 1, false);
 			}
 		return;
 	}
@@ -193,7 +202,7 @@ service_update(struct vlist_tree *tree, struct vlist_node *node_new,
 	s = container_of(node_old, struct service, node);
 	if (!node_new && service_init_announce)
 		vlist_for_each_element(&interfaces, iface, node)
-			service_reply_single(iface, NULL, s, 0, 1);
+			service_reply_single(iface, NULL, s, 0, 1, false);
 	free(s);
 }
 
@@ -207,14 +216,14 @@ hostname_update(struct vlist_tree *tree, struct vlist_node *node_new,
 	if (!node_old) {
 		h = container_of(node_new, struct hostname, node);
 		vlist_for_each_element(&interfaces, iface, node)
-			dns_reply_a(iface, NULL, announce_ttl, h->hostname);
+			dns_reply_a(iface, NULL, announce_ttl, h->hostname, false);
 		return;
 	}
 
 	h = container_of(node_old, struct hostname, node);
 	if (!node_new)
 		vlist_for_each_element(&interfaces, iface, node)
-			dns_reply_a(iface, NULL, 0, h->hostname);
+			dns_reply_a(iface, NULL, 0, h->hostname, false);
 
 	free(h);
 }

--- a/service.c
+++ b/service.c
@@ -20,6 +20,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <time.h>
+#include <string.h>
 
 #include <libubus.h>
 #include <libubox/uloop.h>
@@ -98,6 +99,7 @@ service_add_srv(const char *name, struct service *s, int ttl)
 	if (len <= sizeof(*sd))
 		return;
 
+	memset(sd, 0, sizeof(*sd));
 	sd->port = cpu_to_be16(s->port);
 	dns_packet_answer(name, TYPE_SRV, mdns_buf, len, ttl);
 }

--- a/service.c
+++ b/service.c
@@ -90,7 +90,7 @@ service_add_ptr(const char *name, const char *host, int ttl)
 }
 
 static void
-service_add_srv(const char *name, struct service *s, int ttl)
+service_add_srv(const char *name, struct service *s, int ttl, int answer)
 {
 	struct dns_srv_data *sd = (struct dns_srv_data *) mdns_buf;
 	int len = sizeof(*sd);
@@ -101,7 +101,10 @@ service_add_srv(const char *name, struct service *s, int ttl)
 
 	memset(sd, 0, sizeof(*sd));
 	sd->port = cpu_to_be16(s->port);
-	dns_packet_answer(name, TYPE_SRV, mdns_buf, len, ttl);
+	if (answer)
+		dns_packet_answer(name, TYPE_SRV, mdns_buf, len, ttl);
+	else
+		dns_packet_additional(name, TYPE_SRV, mdns_buf, len, ttl);
 }
 
 #define TOUT_LOOKUP	60
@@ -121,26 +124,34 @@ service_timeout(struct service *s)
 
 static void
 service_reply_single(struct interface *iface, struct sockaddr *to, struct service *s, int ttl, int force,
-			bool append)
+			uint16_t qtype, bool append)
 {
 	const char *host = service_instance_name(s);
 	char *service = strstr(host, "._");
-	time_t t = service_timeout(s);
+	time_t t = force ? 0 : service_timeout(s);
 
-	if (!force && (!s->active || !service || !t))
+	if ((!force && (!s->active || !t)) || !service)
 		return;
 
 	service++;
 
-	s->t = t;
+	if (t)
+		s->t = t;
 
 	if (!append)
 		dns_packet_init();
 
-	service_add_ptr(service, service_instance_name(s), ttl);
-	service_add_srv(host, s, ttl);
-	if (s->txt && s->txt_len)
+	if (qtype == TYPE_ANY || qtype == TYPE_PTR)
+		service_add_ptr(service, service_instance_name(s), ttl);
+	if (qtype == TYPE_ANY || qtype == TYPE_SRV)
+		service_add_srv(host, s, ttl, 1);
+	if (s->txt && s->txt_len && (qtype == TYPE_ANY || qtype == TYPE_TXT))
 		dns_packet_answer(host, TYPE_TXT, (uint8_t *) s->txt, s->txt_len, ttl);
+	if (qtype == TYPE_PTR) {
+		service_add_srv(host, s, ttl, 0);
+		if (s->txt && s->txt_len)
+			dns_packet_additional(host, TYPE_TXT, (uint8_t *) s->txt, s->txt_len, ttl);
+	}
 
 	if (!append)
 		dns_packet_send(iface, to, 0, 0);
@@ -148,7 +159,7 @@ service_reply_single(struct interface *iface, struct sockaddr *to, struct servic
 
 void
 service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force,
-		bool append)
+		uint16_t qtype, bool append)
 {
 	struct service *s;
 
@@ -157,7 +168,7 @@ service_reply(struct interface *iface, struct sockaddr *to, const char *instance
 			continue;
 		if (service_domain && strcmp(s->service, service_domain))
 			continue;
-		service_reply_single(iface, to, s, ttl, force, append);
+		service_reply_single(iface, to, s, ttl, force, qtype, append);
 	}
 }
 
@@ -194,7 +205,7 @@ service_update(struct vlist_tree *tree, struct vlist_node *node_new,
 		if (service_init_announce)
 			vlist_for_each_element(&interfaces, iface, node) {
 				s->t = 0;
-				service_reply_single(iface, NULL, s, announce_ttl, 1, false);
+			service_reply_single(iface, NULL, s, announce_ttl, 1, TYPE_ANY, false);
 			}
 		return;
 	}
@@ -202,7 +213,7 @@ service_update(struct vlist_tree *tree, struct vlist_node *node_new,
 	s = container_of(node_old, struct service, node);
 	if (!node_new && service_init_announce)
 		vlist_for_each_element(&interfaces, iface, node)
-			service_reply_single(iface, NULL, s, 0, 1, false);
+			service_reply_single(iface, NULL, s, 0, 1, TYPE_ANY, false);
 	free(s);
 }
 

--- a/service.h
+++ b/service.h
@@ -42,8 +42,8 @@ extern struct vlist_tree announced_services;
 
 extern void service_init(int announce);
 extern void service_cleanup(void);
-extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force);
-extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl);
+extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force, bool append);
+extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl, bool append);
 extern void service_update(struct vlist_tree *tree, struct vlist_node *node_new, struct vlist_node *node_old);
 
 #endif

--- a/service.h
+++ b/service.h
@@ -14,6 +14,7 @@
 #ifndef _SERVICE_H__
 #define _SERVICE_H__
 
+#include <stdint.h>
 #include <libubox/vlist.h>
 #include <libubox/avl-cmp.h>
 
@@ -42,7 +43,7 @@ extern struct vlist_tree announced_services;
 
 extern void service_init(int announce);
 extern void service_cleanup(void);
-extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force, bool append);
+extern void service_reply(struct interface *iface, struct sockaddr *to, const char *instance, const char *service_domain, int ttl, int force, uint16_t qtype, bool append);
 extern void service_announce_services(struct interface *iface, struct sockaddr *to, int ttl, bool append);
 extern void service_update(struct vlist_tree *tree, struct vlist_node *node_new, struct vlist_node *node_old);
 


### PR DESCRIPTION
On 64-bit architectures (e.g., aarch64), `size_t` is 8 bytes, while `int` remains 4 bytes. The `calloc_a` macro uses variadic arguments (`...`) to read memory allocation lengths via `va_arg(ap, size_t)`.

If a 32-bit integer (like `tlen`, `dlen`, `txt_len`, or `0` in a ternary operator) is passed without an explicit cast, the compiler will not automatically promote it to 64-bit. As a result, `va_arg` reads 8 bytes, consuming the 32-bit value plus adjacent stack garbage. This triggers massive, uncontrolled memory allocations (e.g., attempting to malloc 508GB) and causes immediate OOM crashes.

This patch explicitly casts all length arguments passed to `calloc_a` to `(size_t)` in `cache.c` and `service.c`, ensuring safe memory allocation across all architectures.